### PR TITLE
migrations: use blob instead of postgres-specific bytea

### DIFF
--- a/migrations/00000000000001_create_users.up.fizz
+++ b/migrations/00000000000001_create_users.up.fizz
@@ -4,7 +4,7 @@ create_table("users", func(t) {
 	t.Column("email", "string", {})
 	t.Column("password_hash", "string", {})
 	t.Column("full_name", "string", {})
-	t.Column("avatar", "bytea", {})
+	t.Column("avatar", "blob", {})
 	t.Column("admin", "bool", {})
 	t.Column("subscriptions", "varchar[]", {"null": true})
 })

--- a/migrations/00000000000005_create_forums.up.fizz
+++ b/migrations/00000000000005_create_forums.up.fizz
@@ -2,5 +2,5 @@ create_table("forums", func(t) {
 	t.Column("id", "uuid", {"primary": true})
 	t.Column("title", "string", {})
 	t.Column("description", "string", {})
-	t.Column("logo", "bytea", {})
+	t.Column("logo", "blob", {})
 })


### PR DESCRIPTION
This CL uses the SQL compliant type BLOB instead of the
PostgreSQL-specific 'bytea', to describe binary blobs of data.

Fixes go-saloon/saloon#18.